### PR TITLE
According to the TLS specification the handshake message certificate_…

### DIFF
--- a/js/tls.js
+++ b/js/tls.js
@@ -3197,13 +3197,14 @@ tls.createCertificateRequest = function(c) {
   // common RSA certificate type
   certTypes.putByte(0x01);
 
-  // TODO: verify that this data format is correct
   // add distinguished names from CA store
   var cAs = forge.util.createBuffer();
   for(var key in c.caStore.certs) {
     var cert = c.caStore.certs[key];
     var dn = forge.pki.distinguishedNameToAsn1(cert.subject);
-    cAs.putBuffer(forge.asn1.toDer(dn));
+    var byteBuffer = forge.asn1.toDer(dn);
+    cAs.putInt16(byteBuffer.length());
+    cAs.putBuffer(byteBuffer);
   }
 
   // TODO: TLS 1.2+ has a different format


### PR DESCRIPTION
…request, sent as part of the server_hello messages, should include the length of each individual distinguished name before the distinguished name itself.

Made sure the pull request is now based on the latest 0.6.x release of Forge.